### PR TITLE
Fix Decomposer usage in comparison

### DIFF
--- a/src/main/java/com/sangupta/bloomfilter/AbstractBloomFilter.java
+++ b/src/main/java/com/sangupta/bloomfilter/AbstractBloomFilter.java
@@ -24,6 +24,8 @@ package com.sangupta.bloomfilter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 
 import com.sangupta.bloomfilter.core.BitArray;
@@ -391,8 +393,8 @@ public abstract class AbstractBloomFilter<T> implements BloomFilter<T> {
 		if(value == null) {
 			return false;
 		}
-		
-		return contains(value.toString().getBytes(this.currentCharset));
+
+		return contains(decomposedValue(value));
 	}
 	
 	/**

--- a/src/test/java/com/sangupta/bloomfilter/TestBloomFilter.java
+++ b/src/test/java/com/sangupta/bloomfilter/TestBloomFilter.java
@@ -21,10 +21,15 @@
 
 package com.sangupta.bloomfilter;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.sangupta.bloomfilter.core.BitArray;
+import com.sangupta.bloomfilter.core.JavaBitSetArray;
+import com.sangupta.bloomfilter.decompose.ByteSink;
+import com.sangupta.bloomfilter.decompose.Decomposer;
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -99,4 +104,23 @@ public class TestBloomFilter {
 		System.out.println("False positives found in two millions: " + fpp);
 	}
 
+	@Test
+	public void testDelegatesFilter() {
+		String input = "hello";
+
+		BloomFilter<String> filter = new AbstractBloomFilter<String>(10 * MAX, FPP, new Decomposer<String>() {
+			@Override
+			public void decompose(String object, ByteSink sink) {
+				sink.putBytes(new StringBuilder(object).reverse().toString().getBytes(Charset.defaultCharset()));
+			}
+		}) {
+
+			@Override
+			protected BitArray createBitArray(int numBits) {
+				return new JavaBitSetArray(numBits);
+			}
+		};
+		filter.add(input);
+		Assert.assertTrue(filter.contains(input));
+	}
 }


### PR DESCRIPTION
When a decomposer is used, use it for the comparison as well. Previously it would fail if the composition was different than a toString() on the value.